### PR TITLE
Remove unused `open`

### DIFF
--- a/examples/Counter/build.fsx
+++ b/examples/Counter/build.fsx
@@ -12,7 +12,6 @@ open System
 open Fake.Core
 open Fake.DotNet
 open Fake.IO
-open Fake.Runtime
 open ServerCode.Version
 
 let serverPath = Path.getFullName "./src/Server"


### PR DESCRIPTION
Fake.Runtime is not referenced, so the build failed with the following message:

```
Script is not valid:
        ...\Elmish.Streams\examples\Counter\build.fsx (15,10)-(15,17): Error FS0039: The namespace 'Runtime' is not defined.
```

Without opening `Fake.Runtime` the build works for me.