### PR TITLE
Dispose subscription when client disconnected

### DIFF
--- a/AspNetCore.Middleware/StreamsMiddleware.fs
+++ b/AspNetCore.Middleware/StreamsMiddleware.fs
@@ -98,7 +98,7 @@ module Middleware =
 
                 // Stitch stream and subscribe
                 let msgs = options.Stream connectionId stream
-                do! msgs.RunAsync msgObserver
+                let! subscription = msgs.SubscribeAsync msgObserver
 
                 let buffer : byte [] = Array.zeroCreate 4096
                 while not finished do
@@ -129,6 +129,8 @@ module Middleware =
                     | Choice2Of2 closeStatus ->
                         finished <- true
                         closure <- closeStatus
+
+                do! subscription.DisposeAsync()
 
                 logger.LogInformation ("Closing WebSocket with ID: {ConnectionID}", connectionId)
                 try


### PR DESCRIPTION
Feels a bit dirty to not put that in a `use` or `try/finally` block, but `use` doesn't support `IAsyncDisposable` and `try/finally` doesn't support asyncs it seems. Any idea?