### PR TITLE
Replace obsolete `IApplicationLifetime` with `IHostApplicationLifetime`

### DIFF
--- a/AspNetCore.Middleware/StreamsMiddleware.fs
+++ b/AspNetCore.Middleware/StreamsMiddleware.fs
@@ -40,7 +40,7 @@ module Middleware =
             let loggerFactory  = ctx.RequestServices.GetService<ILoggerFactory> ()
             let logger = loggerFactory.CreateLogger("Elmish.Streams.Middleware")
 
-            let appLifetime  = ctx.RequestServices.GetService<IApplicationLifetime> ()
+            let appLifetime  = ctx.RequestServices.GetService<IHostApplicationLifetime> ()
             
             let defaultOptions = {
                 Stream = fun _ msgs -> msgs


### PR DESCRIPTION
I just saw that with the currently used version of `Microsoft.AspNetCore.Hosting` `IApplicationLifetime` is marked as obsolete and `IHostApplicationLifetime` should be used instead. But apart from the name there doesn't seem to be a difference.