### PR TITLE
Remove unused reference to Giraffe

### DIFF
--- a/AspNetCore.Middleware/paket.dependencies
+++ b/AspNetCore.Middleware/paket.dependencies
@@ -3,8 +3,6 @@ source https://api.nuget.org/v3/index.json
 
 nuget FSharp.Core
 
-nuget Giraffe ~> 4
-
 nuget Microsoft.AspNetCore
 nuget Microsoft.AspNetCore.WebSockets
 

--- a/AspNetCore.Middleware/paket.lock
+++ b/AspNetCore.Middleware/paket.lock
@@ -8,18 +8,6 @@ NUGET
       FSharp.Core (>= 3.1.2) - restriction: >= net45
       FSharp.Core (>= 4.3.2) - restriction: && (< net45) (>= netstandard2.0)
     FSharp.Core (4.7.2)
-    Giraffe (4.1)
-      FSharp.Core (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Authorization (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Diagnostics (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.ResponseCaching (>= 2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.IO.RecyclableMemoryStream (>= 1.2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Newtonsoft.Json (>= 12.0.2) - restriction: || (>= net461) (>= netstandard2.0)
-      System.ValueTuple (>= 4.4) - restriction: >= net461
-      TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
     Microsoft.AspNetCore (2.2)
       Microsoft.AspNetCore.Diagnostics (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.HostFiltering (>= 2.2) - restriction: >= netstandard2.0
@@ -39,15 +27,7 @@ NUGET
       Microsoft.Extensions.Logging.Console (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Debug (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.EventSource (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Authentication.Abstractions (2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
@@ -55,27 +35,11 @@ NUGET
       Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization (3.1.4) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Metadata (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 3.1.4) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Connections.Abstractions (3.1.4) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Features (>= 3.1.4) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 1.1.1) - restriction: && (>= netstandard2.0) (< netstandard2.1)
       System.IO.Pipelines (>= 4.7.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-    Microsoft.AspNetCore.DataProtection (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Cryptography.Internal (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Win32.Registry (>= 4.7) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Xml (>= 4.7) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
-    Microsoft.AspNetCore.DataProtection.Abstractions (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-    Microsoft.AspNetCore.Diagnostics (2.2) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.AspNetCore.Diagnostics (2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
@@ -85,7 +49,7 @@ NUGET
       Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.HostFiltering (2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
@@ -105,11 +69,11 @@ NUGET
       Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5.1) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Abstractions (2.2) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.AspNetCore.Hosting.Abstractions (2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Http (2.2.2) - restriction: >= netstandard2.0
@@ -133,15 +97,6 @@ NUGET
       Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Metadata (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-    Microsoft.AspNetCore.ResponseCaching (2.2) - restriction: || (>= net461) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.2) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.Routing (2.2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
       Microsoft.AspNetCore.Routing.Abstractions (>= 2.2) - restriction: >= netstandard2.0
@@ -206,15 +161,8 @@ NUGET
     Microsoft.AspNetCore.WebUtilities (2.2) - restriction: >= netstandard2.0
       Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Bcl.AsyncInterfaces (1.1.1) - restriction: || (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    Microsoft.Bcl.AsyncInterfaces (1.1.1) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= netstandard2.1)
-    Microsoft.Extensions.Caching.Abstractions (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.Extensions.Primitives (>= 3.1.4) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.Extensions.Caching.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 3.1.4) - restriction: >= netstandard2.0
     Microsoft.Extensions.Configuration (3.1.4) - restriction: >= netstandard2.0
       Microsoft.Extensions.Configuration.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
     Microsoft.Extensions.Configuration.Abstractions (3.1.4) - restriction: >= netstandard2.0
@@ -283,90 +231,50 @@ NUGET
     Microsoft.Extensions.Primitives (3.1.4) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.2) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
       System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
-    Microsoft.Extensions.WebEncoders (3.1.4) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 3.1.4) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 3.1.4) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.7.1) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
-    Microsoft.IO.RecyclableMemoryStream (1.3.4) - restriction: || (>= net461) (>= netstandard2.0)
-      NETStandard.Library (>= 1.6.1) - restriction: && (< net40) (< netcoreapp2.1) (>= netstandard1.4) (< netstandard2.1)
     Microsoft.Net.Http.Headers (2.2.8) - restriction: >= netstandard2.0
       Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.NETCore.Platforms (3.1.1) - restriction: || (&& (< net40) (>= net45) (< netstandard1.3) (>= netstandard2.0)) (&& (< net40) (>= net46) (< netstandard1.4) (>= netstandard2.0)) (&& (< net40) (>= net461)) (&& (< net40) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< net40) (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< net40) (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< net40) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< net40) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.4) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.5) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (< netstandard1.6) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net40) (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (< netstandard1.0) (>= win8)) (&& (>= net461) (< netstandard1.3) (>= wpa81)) (&& (>= net461) (< netstandard1.5) (>= uap10.0)) (&& (>= net461) (>= uap10.1)) (&& (>= net461) (>= wp8)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8))
-    Microsoft.Win32.Registry (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      System.Buffers (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.3) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
-      System.Security.AccessControl (>= 4.7) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Security.Principal.Windows (>= 4.7) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    NETStandard.Library (2.0.3) - restriction: || (&& (< net40) (>= net461)) (&& (< net40) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
-    Newtonsoft.Json (12.0.3) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Buffers (4.5.1) - restriction: || (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (&& (>= netcoreapp2.0) (< netstandard1.1)) (&& (>= netcoreapp2.0) (>= xamarinios)) (&& (>= netcoreapp2.0) (>= xamarinmac)) (&& (>= netcoreapp2.0) (>= xamarintvos)) (&& (>= netcoreapp2.0) (>= xamarinwatchos)) (>= netstandard2.0) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
-    System.Collections.Immutable (1.7.1) - restriction: || (&& (< net45) (< netcoreapp3.0) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8))
-      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (< netstandard2.0)) (>= net461) (>= uap10.1)
-    System.ComponentModel.Annotations (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
+    Microsoft.NETCore.Platforms (3.1.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
+    System.Buffers (4.5.1) - restriction: || (&& (>= monoandroid) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= xamarinios)) (&& (>= net461) (>= xamarinmac)) (&& (>= netcoreapp2.0) (< netstandard1.1)) (&& (>= netcoreapp2.0) (>= xamarinios)) (&& (>= netcoreapp2.0) (>= xamarinmac)) (&& (>= netcoreapp2.0) (>= xamarintvos)) (&& (>= netcoreapp2.0) (>= xamarinwatchos)) (>= netstandard2.0) (&& (>= uap10.1) (>= xamarinios)) (&& (>= uap10.1) (>= xamarinmac))
+    System.Collections.Immutable (1.7.1) - restriction: || (&& (< net45) (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8))
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (< netstandard2.0)) (>= net461) (>= uap10.1)
+    System.ComponentModel.Annotations (4.7) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
     System.Diagnostics.DiagnosticSource (4.7.1) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (>= net45) (< netstandard1.3)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net46) (>= uap10.1)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net45) (< netstandard1.3)) (>= net46) (>= uap10.1)
     System.IO.Pipelines (4.7.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (>= monotouch) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
-    System.Memory (4.5.4) - restriction: || (&& (>= net461) (>= netcoreapp2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= netstandard2.0)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Numerics.Vectors (>= 4.4) - restriction: && (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
+      System.Buffers (>= 4.5.1) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (>= net461) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (< netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< netstandard2.0) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (>= net46) (< netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+    System.Memory (4.5.4) - restriction: || (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netcoreapp2.1)) (&& (>= net461) (>= netcoreapp3.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (>= uap10.1)) (&& (>= netcoreapp2.1) (>= uap10.1)) (&& (< netcoreapp2.1) (>= netcoreapp3.0) (< netstandard2.1)) (&& (>= netcoreapp3.0) (>= uap10.1)) (>= netstandard2.0)
+      System.Buffers (>= 4.5.1) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Numerics.Vectors (>= 4.4) - restriction: && (< monoandroid) (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)
       System.Numerics.Vectors (>= 4.5) - restriction: >= net461
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     System.Net.WebSockets.WebSocketProtocol (4.7.1) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= uap10.1)
-      System.Numerics.Vectors (>= 4.5) - restriction: || (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac))
-      System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= uap10.1)
+      System.Buffers (>= 4.5.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+      System.Numerics.Vectors (>= 4.5) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461)
+      System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
     System.Numerics.Vectors (4.5) - restriction: >= netstandard2.0
-    System.Reflection.Emit (4.7) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47)
-      System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
-    System.Reflection.Emit.ILGeneration (4.7) - restriction: || (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (< net45) (>= net461) (< netstandard2.0)) (&& (< net45) (>= net47) (>= netstandard2.0)) (&& (< net45) (>= net47) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= net461) (< netstandard1.1)) (&& (>= net461) (< netstandard2.0) (>= wpa81)) (&& (>= net461) (>= uap10.1)) (&& (>= net47) (< netstandard1.1)) (&& (>= net47) (< netstandard2.0) (>= wpa81)) (&& (>= net47) (>= uap10.1)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (>= netstandard2.0) (>= uap10.1))
-    System.Reflection.Emit.Lightweight (4.7) - restriction: || (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47)
-      System.Reflection.Emit.ILGeneration (>= 4.7) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wp8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (< netstandard2.0) (>= wpa81)) (&& (>= portable-net45+win8+wp8+wpa81) (< portable-net45+wp8) (< win8)) (&& (< portable-net45+wp8) (>= win8)) (>= uap10.1)
     System.Reflection.Metadata (1.8.1) - restriction: >= netstandard2.0
       System.Collections.Immutable (>= 1.7.1) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp3.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81))
     System.Runtime.CompilerServices.Unsafe (4.7.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= netstandard2.0)
-    System.Security.AccessControl (4.7) - restriction: || (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp3.0) (>= netstandard2.0)) (&& (>= net461) (>= netcoreapp2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp3.0)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
-      Microsoft.NETCore.Platforms (>= 3.1) - restriction: >= netcoreapp2.0
-      System.Security.Principal.Windows (>= 4.7) - restriction: || (&& (>= net46) (< netstandard2.0)) (&& (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Cryptography.Cng (4.7) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (&& (< netcoreapp2.0) (>= netstandard2.1)) (&& (>= netcoreapp2.1) (< netstandard2.1)) (>= netstandard2.0)
+    System.Security.Cryptography.Cng (4.7) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: && (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)
-    System.Security.Cryptography.Pkcs (4.7) - restriction: && (< net461) (< netcoreapp3.0) (>= netstandard2.0)
-      System.Buffers (>= 4.5) - restriction: && (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)
-      System.Memory (>= 4.5.3) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (>= uap10.1)
-      System.Security.Cryptography.Cng (>= 4.7) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< netstandard2.1) (< xamarinios) (< xamarinmac)) (&& (>= netcoreapp2.0) (< netcoreapp2.1) (< netstandard2.1)) (&& (< netcoreapp2.0) (>= netstandard2.1)) (&& (>= netcoreapp2.1) (< netstandard2.1)) (>= netcoreapp3.0)
-    System.Security.Cryptography.Xml (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      System.Security.Cryptography.Pkcs (>= 4.7) - restriction: && (< net461) (>= netstandard2.0)
-      System.Security.Permissions (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.7) - restriction: || (&& (>= net461) (>= netstandard2.0)) (&& (< netcoreapp3.0) (>= netstandard2.0))
-      System.Security.AccessControl (>= 4.7) - restriction: || (>= net461) (>= netstandard2.0)
     System.Security.Principal.Windows (4.7) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 3.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0))
-    System.Text.Encodings.Web (4.7.1) - restriction: || (&& (>= monotouch) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (&& (< netcoreapp3.0) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Text.Encodings.Web (4.7.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= netstandard2.0)
       System.Memory (>= 4.5.4) - restriction: || (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< netstandard2.1)) (>= net461) (>= uap10.1)
     System.Text.Json (4.7.2) - restriction: && (< netcoreapp3.1) (>= netstandard2.0)
-      Microsoft.Bcl.AsyncInterfaces (>= 1.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= uap10.1)
-      System.Numerics.Vectors (>= 4.5) - restriction: || (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac))
-      System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Text.Encodings.Web (>= 4.7.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= uap10.1)
+      Microsoft.Bcl.AsyncInterfaces (>= 1.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Buffers (>= 4.5.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
+      System.Numerics.Vectors (>= 4.5) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461)
+      System.Runtime.CompilerServices.Unsafe (>= 4.7.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Text.Encodings.Web (>= 4.7.1) - restriction: || (>= monoandroid) (>= monotouch) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.1) (< netcoreapp3.0)) (&& (>= netcoreapp3.0) (< netcoreapp3.1)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (< monoandroid) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
       System.ValueTuple (>= 4.5) - restriction: >= net461
-    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
-    System.ValueTuple (4.5) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.6) (>= netstandard2.0)) (>= net461)
-    TaskBuilder.fs (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      FSharp.Core (>= 4.1.17) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
-      NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.6)
-      System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
-    Utf8Json (1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Reflection.Emit (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.Threading.Tasks.Extensions (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
+    System.Threading.Tasks.Extensions (4.5.4) - restriction: || (&& (>= net461) (>= netstandard2.1)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios) (< xamarinmac)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (>= net461) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
+    System.ValueTuple (4.5) - restriction: && (>= net461) (>= netstandard2.0)

--- a/AspNetCore.Middleware/paket.references
+++ b/AspNetCore.Middleware/paket.references
@@ -1,5 +1,4 @@
 FSharp.Core
-Giraffe
 Microsoft.AspNetCore
 Microsoft.AspNetCore.WebSockets
 FSharp.Control.AsyncRx


### PR DESCRIPTION
Something weird is going on with my references to the ASP.NET Core NuGet packages (`MissingMethodException`s). I'm not sure where that comes from, but maybe removing unused references helps :shrug: