### PR TITLE
Fix race condition in AsyncRx.merge

### DIFF
--- a/AsyncRx/test/MergeTest.fs
+++ b/AsyncRx/test/MergeTest.fs
@@ -94,4 +94,25 @@ let tests = testList "Merge Tests" [
         Expect.contains actual (OnNext 5) "Should contain the element"
         Expect.contains actual (OnCompleted) "Should contain the element"
     }
+
+    testAsync "Test subscribe immediately" {
+        // Arrange
+        let obv, stream = AsyncRx.subject<int> ()
+        let msgs =
+            stream
+            |> AsyncRx.merge (AsyncRx.empty ())
+
+        let testObv = TestObserver<int>()
+
+        // Act
+        let! subscription = msgs.SubscribeAsync testObv
+        // do! Async.Sleep 100 // uncomment this line and the test will pass
+        do! obv.OnNextAsync 1
+        do! Async.Sleep 100
+        do! obv.OnCompletedAsync ()
+        do! testObv.AwaitIgnore ()
+
+        // Assert
+        Expect.sequenceEqual testObv.Notifications [OnNext 1; OnCompleted] "Should have received one OnNext and OnCompleted notifications"
+    }
 ]


### PR DESCRIPTION
`Combine.mergeInner` seems to have a race condition when an element is posted to the underlying stream immediately after subscribing to the observable. I added a test that currently fails. However when you put a sleep between subscribing and posting the element it starts to work.
I assume that the problem is that the sequence of observables is posted to the mailbox processor withing `mergeInner`, but it doesn't wait until the inner observable is subscribed to.
Any idea how to fix this?