### PR TITLE
Add type annotations for Asycn.Sleep for Fable on net5.0

### DIFF
--- a/AsyncRx/src/Create.fs
+++ b/AsyncRx/src/Create.fs
@@ -147,7 +147,7 @@ module internal Create =
         let subscribeAsync  (aobv : IAsyncObserver<int>) : Async<IAsyncRxDisposable> =
             let cancel, token = canceller ()
             async {
-                let rec handler msecs next = async {
+                let rec handler (msecs : int) next = async {
                     do! Async.Sleep msecs
                     do! aobv.OnNextAsync next
 

--- a/AsyncRx/src/Timeshift.fs
+++ b/AsyncRx/src/Timeshift.fs
@@ -50,7 +50,7 @@ module internal Timeshift =
 
     /// Ignores values from an observable sequence which are followed by
     /// another value before the given timeout.
-    let debounce msecs (source: IAsyncObservable<'TSource>) : IAsyncObservable<'TSource> =
+    let debounce (msecs : int) (source: IAsyncObservable<'TSource>) : IAsyncObservable<'TSource> =
         let subscribeAsync (aobv: IAsyncObserver<'TSource>) =
             let safeObv, autoDetach = autoDetachObserver aobv
             let infinite = Seq.initInfinite id


### PR DESCRIPTION
For some incomprehensible reason Fable fails to compile `FSharp.Control.AsycRx` under `dotnet 5.0.100-rc.1.20452.10`. Compilation fails because:

```
SHARP: A unique overload for method 'Async.Sleep' could not be determined based on type information 
prior to this program point. A type annotation may be needed.
```

Everything compiles straight without problems with `dotnet build`, but Fable trips on missing type annotations.